### PR TITLE
fix(output path): use lastIndexOf to maintain entire inputPath

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ export default function ssr(options = {}) {
       }
 
       const destPath = path.relative("./", config.file);
-      const destDir = destPath.slice(0, destPath.indexOf(path.sep));
+      const destDir = destPath.slice(0, destPath.lastIndexOf(path.sep));
 
       Object.keys(bundle).forEach(async key => {
         const entry = bundle[key];


### PR DESCRIPTION
This fixes an issue where a path like `../../../some/path/file.js` gets converted to `..` instead if `../../../some/path`.